### PR TITLE
feat: add deploy inside CI/CD config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,4 +45,4 @@ jobs:
         USERNAME: ${{ secrets.USERNAME }}
         PORT: ${{ secrets.PORT }}
         KEY: ${{ secrets.SSHKEY }}
-        script: /opt/app/deploy-prod.sh
+        script: PROJECT_HOME=/opt/app /opt/app/deploy-prod.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,11 @@ jobs:
         source: "."
         target: "/opt/app" # update to appropriate target
 
-    - name: Executing remote  command
+    - name: Executing deploy command
       uses: appleboy/ssh-action@master
       with:
         host: ${{ secrets.HOST }}
         USERNAME: ${{ secrets.USERNAME }}
         PORT: ${{ secrets.PORT }}
         KEY: ${{ secrets.SSHKEY }}
-        script: ./opt/app/deploy-prod.sh
+        script: /opt/app/deploy-prod.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push]
+on:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -24,3 +26,23 @@ jobs:
         ls -al frontend
         echo "Backend:"
         ls -al backend
+    
+    - name: Copy file via scp
+      uses: appleboy/scp-action@master
+      env:
+        HOST: ${{ secrets.HOST }}
+        USERNAME: ${{ secrets.USERNAME }}
+        PORT: ${{ secrets.PORT }}
+        KEY: ${{ secrets.SSHKEY }}
+      with:
+        source: "."
+        target: "/opt/app" # update to appropriate target
+
+    - name: Executing remote  command
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.HOST }}
+        USERNAME: ${{ secrets.USERNAME }}
+        PORT: ${{ secrets.PORT }}
+        KEY: ${{ secrets.SSHKEY }}
+        script: ./opt/app/deploy-prod.sh

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cd /opt/app/ && docker-compose -f docker-compose.prod.yaml up --build
+cd ${PROJECT_HOME} && docker-compose -f docker-compose.prod.yaml up --build

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cd /opt/app/ && docker-compose -f docker-compose.prod.yaml up --build


### PR DESCRIPTION
That's not the whole work to make this working correctly. Add **HOST, USERNAME, PORT, SSHKEY** to the [Github secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets). The deploy will be triggered when a new release gets published. 

P.S.: I didn't check it on my own repo, so it's **highly advisable** to do it before using in real life