### PR TITLE
Add docker-compose config for maintenance page

### DIFF
--- a/docker-compose.maintenance.yaml
+++ b/docker-compose.maintenance.yaml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  maintenance:
+    image: nginx:alpine
+    volumes:
+      - ./frontend/maintenance:/usr/share/nginx/html
+    ports:
+      - 80:80


### PR DESCRIPTION
To be run with `docker-compose -f docker-compose.maintenance.yaml up` after stopping the other services